### PR TITLE
Adding new Event Overlay plot

### DIFF
--- a/WormTracker3000.m
+++ b/WormTracker3000.m
@@ -6,8 +6,8 @@ function [] = WormTracker3000()
 %
 %   Code designed and created by Astra S. Bryant, PhD
 %
-%   Version 0.3
-%   Version Date: July 2022
+%   Version 0.5
+%   Version Date: Nov 2022
 
 close all; clear all
 warning('off');
@@ -15,10 +15,6 @@ global info
 global dat
 global vals
 global tracks
-
-% %% User Provided Variables (used during plotting) - logical values
-% subsetplot = 1; %Generate subset plot y/n (logical)? Note: if there are less than 10 worms, the subset plot won't be generated anyway.
-% individualplots = 0; % Generate individual plots for each track y/n (logical)?
 
 %% Load experimental parameters and data
 load_files();
@@ -32,6 +28,11 @@ load_params()
 
 %% Load track data
 load_tracks()
+
+%% Load overlay information (if exists)
+if any(contains(info.sheets, 'Overlay'))
+    load_overlay()
+end
 
 %% Process data
 if contains(info.assaytype, 'Bact_4.9') || contains(info.assaytype, 'C02_3.75') ...

--- a/load_files.m
+++ b/load_files.m
@@ -24,13 +24,18 @@ info.calledfile = fullfile(pathstr,name);
 %% Determine the type of assay being analyzed
 [selection, ok] = listdlg('Name','Select Assay Type',...
     'PromptString','Pick an assay type',...
-    'ListString',{'Pure Thermotaxis'; ...
-    'Thermotaxis + Odor (not supported)'; ...
-    'Isothermal Odor (22 cm arena - not supported)'; 'Pure Isothermal (22 cm arena - not supported)';...
-    'Bacterial Assay (4.9 cm arena)'; 'CO2 Gradient (3.75 cm arena)';...
-    'Pheromone Assay (5 cm arena)'; 'Odor Assay (5 cm arena)'; ...
-    'Gas Shift Chamber';'Sweat Accumulation'; ...
-    'Custom linear assay'; 'Basic track info'},...
+    'ListString',{'Basic track info'; ...
+    'Custom linear assay'; ...
+    'Pure Thermotaxis'; ...
+    %'Thermotaxis + Odor (not supported)'; ...
+    %'Isothermal Odor (22 cm arena - not supported)'; ...
+    %'Pure Isothermal (22 cm arena - not supported)';...
+    'Bacterial Assay (4.9 cm arena)'; ...
+    'CO2 Gradient (3.75 cm arena)';...
+    'Pheromone Assay (5 cm arena)'; ...
+    'Odor Assay (5 cm arena)'; ...
+    %'Gas Shift Chamber'; ...
+    %'Sweat Accumulation'}, ...
     'SelectionMode','single','ListSize',[200 150]);
 % Handle response
 if ok < 1
@@ -39,43 +44,40 @@ end
 
 switch selection
     case 1
-        info.assaytype = 'Thermo_22'; % Pure Thermotaxis Gradient
-        info.presets = 'Thermotaxis';
-    case 2
-        info.assaytype = 'OdorThermo_22'; % Multisensory Experiment, i.e. Odor + Thermal Gradient
-        info.presets = 'Thermotaxis';
-    case 3
-        info.assaytype = 'Odor_22'; % Pure Odor Experiment 22 cm arena, i.e. Odor on isothermal plate
-        info.presets = 'Odors/Gas/Bacteria';
-    case 4
-        info.assaytype = 'Iso_22'; % Isothermal 22cm arena, i.e. unstimulated experiment
-        info.presets = 'Basic info';
-    case 5
-        info.assaytype = 'Bact_4.9'; % Bacterial Assay (4.9 cm arena)
-        info.presets = 'Odors/Gas/Bacteria';
-    case 6
-        info.assaytype = 'C02_3.75'; % C02 Assay (3.75 cm arena)
-        info.presets = 'Odors/Gas/Bacteria';
-    case 7
-        info.assaytype = 'Pher_5'; % Pheromone Assay (5 cm arena)
-        info.presets = 'Odors/Gas/Bacteria';
-    case 8
-        info.assaytype = 'Odor_5'; % Odor Assay (5 cm arena)
-        info.presets = 'Odors/Gas/Bacteria';
-    case 9
-        info.assaytype = 'GasShift'; % Chamber for sequential presentation of gases
-         info.presets = 'Basic info';
-    case 10
-        info.assaytype = 'SweatAccumulation'; % Sweat accumulation assay
-         info.presets = 'Basic info';
-    case 11
-        info.assaytype = 'Custom_linear'; % Custom assay with a linear gradient
-         info.presets = 'Thermotaxis';
-    case 12
         info.assaytype = 'Basic_info'; % Basic information about distances moved, no gradient information
         info.presets = 'Basic info';
-%     case 12
-%         info.assaytype = 'Custom_circle'; % Custom circular assay
+    case 2
+        info.assaytype = 'Custom_linear'; % Custom assay with a linear gradient
+        info.presets = 'Thermotaxis';
+    case 3
+        info.assaytype = 'Thermo_22'; % Pure Thermotaxis Gradient
+        info.presets = 'Thermotaxis';
+    case 4
+        info.assaytype = 'Bact_4.9'; % Bacterial Assay (4.9 cm arena)
+        info.presets = 'Odors/Gas/Bacteria';
+    case 5
+        info.assaytype = 'C02_3.75'; % C02 Assay (3.75 cm arena)
+        info.presets = 'Odors/Gas/Bacteria';
+    case 6
+        info.assaytype = 'Pher_5'; % Pheromone Assay (5 cm arena)
+        info.presets = 'Odors/Gas/Bacteria';
+    case 7
+        info.assaytype = 'Odor_5'; % Odor Assay (5 cm arena)
+        info.presets = 'Odors/Gas/Bacteria';
+        %     case 8
+        %         info.assaytype = 'GasShift'; % Chamber for sequential presentation of gases
+        %         info.presets = 'Basic info';
+        %     case 9
+        %         info.assaytype = 'SweatAccumulation'; % Sweat accumulation assay
+        %         info.presets = 'Basic info';
+        %     case 3
+        %         info.assaytype = 'Odor_22'; % Pure Odor Experiment 22 cm arena, i.e. Odor on isothermal plate
+        %         info.presets = 'Odors/Gas/Bacteria';
+        %     case 4
+        %         info.assaytype = 'Iso_22'; % Isothermal 22cm arena, i.e. unstimulated experiment
+        %         info.presets = 'Basic info';
+        %     case 12
+        %         info.assaytype = 'Custom_circle'; % Custom circular assay
 end
 
 

--- a/load_overlay.m
+++ b/load_overlay.m
@@ -1,0 +1,30 @@
+function [] = load_overlay ()
+%%load_overlay: Load overlay information
+
+global info
+global dat
+
+[~, headers, ~] = xlsread(info.calledfile, 'Overlay');
+alphabet = ['A':'Z'];
+
+% Determine number of overlay events
+[I, J] = find(contains(headers, {'Behavior', 'Event', 'Category', 'Type'}));
+info.overlay.Num = size(headers(:,J), 1)-1;
+
+% Behavior Type/Category for each event
+dat.overlay.Event = categorical(headers(2:end,J));
+info.overlay.CatNum = size(categories(dat.overlay.Event),1);
+
+% UniqueIDs for each overlay event
+[I, J] = find(contains(headers, {'UID', 'ID'}));
+dat.overlay.UIDs = headers(2:end, J);
+
+% Frames for each overlay event
+[I, J] = find(contains(headers, {'Frame'}));
+if ~isempty(I) && ~isempty(J)
+dat.overlay.Frame = xlsread(info.calledfile, 'Overlay', strcat(...
+    alphabet(J), num2str(I+1),...
+    ':',alphabet(J), num2str(info.overlay.Num+1)));
+end
+
+

--- a/load_params.m
+++ b/load_params.m
@@ -38,6 +38,12 @@ if ~isempty(I) && ~isempty(J)
         ':',alphabet(J), num2str(info.numworms+1)));
 end
 
+% Quality check
+if info.numworms > size(info.wormUIDs,1)
+    info.numworms = size(info.wormUIDs,1)
+    disp('Warning, the number of unique IDs found is less than the user-specified number of worms. The number of worms variable has been adjusted to match available data.')
+end
+
 % Camera sizing parameter (pixels per cm)
 refstr = {'pixels per cm', 'ppcm', 'pixelspercm'};
 [I, J] = find(contains(headers, refstr));
@@ -355,5 +361,6 @@ if contains(info.assaytype, 'GasShift')
     end
     
 end
+
 
 end

--- a/plot_basic.m
+++ b/plot_basic.m
@@ -7,7 +7,12 @@ fig = DrawThePlot(xvals, yvals, name);
 movegui('northeast');
 
 ax=get(fig,'CurrentAxes');
-set(ax,'XLim',[min(round(min(xvals)))-1 max(round(max(xvals)))+1]);
+if contains(info.assaytype, 'Thermo_22')
+    set(ax,'XLim',[min(round(min(xvals)))-1 max(round(max(xvals)))+1]);
+    set(ax, 'YLim', [-22.5 0]);
+elseif contains(info.assaytype,'Custom_linear')
+    set(ax,'XLim',[min(round(min(xvals)))-1 max(round(max(xvals)))+1]);
+end
 
 setaxes = 1;
 while setaxes>0 % loop through the axes selection until you're happy
@@ -37,10 +42,37 @@ while setaxes>0 % loop through the axes selection until you're happy
             setaxes=-1;
         case 'Cancel'
             setaxes=-1;
-    end   
+    end
 end
 saveas(gcf, fullfile(pathstr,[name,'/', name, '-all.eps']),'epsc');
 saveas(gcf, fullfile(pathstr,[name,'/', name,'-all.png']));
+
+%% Make a plot with an overlay
+if any(contains(info.sheets, 'Overlay'))
+    global dat
+    disp('Generating Overlay Plot')
+    
+    % Find the X/Y coordinates that match the ovelay event UID and frame
+    for i = 1:info.overlay.Num
+        I = find(contains(info.wormUIDs, dat.overlay.UIDs{i}));
+        dat.overlay.Xvals(i,1) = xvals(dat.overlay.Frame(i), I);
+        dat.overlay.Yvals(i,1) = yvals(dat.overlay.Frame(i), I);
+    end
+    % Drawing the Overlay
+    overlayicons = ["diamond", "^", "square", "x", "*", "o"]; % Change this line of code to alter the style of overlay icons used
+    disp('Warning: icon identity may change if the number of overlay category types fluctuates across assays.');
+    disp('For stability, set all overlay event icons to the same marker type in the plot_basic.m file (near the code that generates this message).');
+    temp = categories(dat.overlay.Event);
+    hold on
+    for i = 1:info.overlay.CatNum
+        I = find(dat.overlay.Event == temp{i});
+        plot(dat.overlay.Xvals(I), dat.overlay.Yvals(I), overlayicons(i), 'MarkerSize',10);
+    end
+    hold off
+    
+    saveas(gcf, fullfile(pathstr,[name,'/', name, '-overlay.eps']),'epsc');
+    saveas(gcf, fullfile(pathstr,[name,'/', name,'-overlay.png']));
+end
 
 
 %% Make a plot with a random subset of the tracks
@@ -96,7 +128,7 @@ plot(xvals(1,:),yvals(1,:),'k+'); % plotting starting locations
 
 hold off
 
-% Labeling the figure and saving
+% Labeling the figure
 ylabel('Distance (cm)'); xlabel('Distance (cm)');
 title(name,'Interpreter','none');
 set(gcf, 'renderer', 'Painters');


### PR DESCRIPTION
This addresses issue #10. 

Users may now provide an Overlay tab in their .xslx index file with 3 columns: UID, Frame, Event
The UID should match the worm UID the event belongs to, Frame is a number that enables the code to locate the X/Y coordinates of the event by searching the appropriate UID tab, and Event is a categorical string. Up to 6 distinct event types are supported. 